### PR TITLE
Add Arduino DUE to I2C scan

### DIFF
--- a/Adafruit_TestBed.cpp
+++ b/Adafruit_TestBed.cpp
@@ -371,8 +371,12 @@ void Adafruit_TestBed::beep(uint32_t freq, uint32_t duration) {
   if (piezoPin < 0)
     return;
   pinMode(piezoPin, OUTPUT);
-#if !defined(ARDUINO_ARCH_ESP32)
+#if !defined(ARDUINO_ARCH_ESP32) && !defined(ARDUINO_SAM_DUE)
   tone(piezoPin, freq, duration);
+#else
+  // suppress compiler warns
+  (void)freq;
+  (void)duration;
 #endif
 }
 
@@ -395,7 +399,7 @@ void Adafruit_TestBed::beepNblink(void) {
   if (ledPin >= 0) {
     digitalWrite(ledPin, LOW);
   }
-#if !defined(ARDUINO_ARCH_ESP32)
+#if !defined(ARDUINO_ARCH_ESP32) && !defined(ARDUINO_SAM_DUE)
   noTone(piezoPin);
 #endif
 }

--- a/examples/I2C_Scan/I2C_Scan.ino
+++ b/examples/I2C_Scan/I2C_Scan.ino
@@ -58,12 +58,12 @@ void loop() {
   Serial.println("");
   Serial.println("");
 
-  Serial.print("Default port ");
+  Serial.print("Default port (Wire) ");
   TB.theWire = DEFAULT_I2C_PORT;
   TB.printI2CBusScan();
 
 #if defined(SECONDARY_I2C_PORT)
-  Serial.print("Secondary port ");
+  Serial.print("Secondary port (Wire1) ");
   TB.theWire = SECONDARY_I2C_PORT;
   TB.printI2CBusScan();
 #endif

--- a/examples/I2C_Scan/I2C_Scan.ino
+++ b/examples/I2C_Scan/I2C_Scan.ino
@@ -10,13 +10,14 @@ extern Adafruit_TestBed TB;
     || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) \
     || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) \
     || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) \
-    || defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO)
+    || defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO) \
+    || defined(ARDUINO_SAM_DUE)
   #define SECONDARY_I2C_PORT &Wire1
 #endif
 
 void setup() {
   Serial.begin(115200);
-  
+
   // Wait for Serial port to open
   while (!Serial) {
     delay(10);
@@ -56,7 +57,7 @@ void setup() {
 void loop() {
   Serial.println("");
   Serial.println("");
-  
+
   Serial.print("Default port ");
   TB.theWire = DEFAULT_I2C_PORT;
   TB.printI2CBusScan();


### PR DESCRIPTION
Updates `I2C_Scan` example to work with Arduino DUE.

Also required some minor edits to the library code since DUE has no `tone` implementation.

Tested with a BME680 on `Wire` and a AHT20 on `Wire1`:
![Screenshot from 2022-05-18 11-00-09](https://user-images.githubusercontent.com/8755041/169111510-0255ed3f-350e-49cc-b02c-9075724250a6.png)

