### PR TITLE
Add Wire1 for any RP2040

### DIFF
--- a/Adafruit_TestBed.cpp
+++ b/Adafruit_TestBed.cpp
@@ -231,7 +231,8 @@ bool Adafruit_TestBed::testpins(uint8_t a, uint8_t b, uint8_t *allpins,
 
   // verify neither are grounded
   if (!digitalRead(a) || !digitalRead(b)) {
-    theSerial->println(F("Ground test 1 fail: both pins should not be grounded"));
+    theSerial->println(
+        F("Ground test 1 fail: both pins should not be grounded"));
     return false;
   }
 
@@ -269,7 +270,8 @@ bool Adafruit_TestBed::testpins(uint8_t a, uint8_t b, uint8_t *allpins,
       || !digitalRead(b)
 #endif
   ) {
-    theSerial->println(F("Ground test 2 fail: both pins should not be grounded"));
+    theSerial->println(
+        F("Ground test 2 fail: both pins should not be grounded"));
     delay(100);
     return false;
   }

--- a/Adafruit_TestBed.h
+++ b/Adafruit_TestBed.h
@@ -49,8 +49,8 @@ public:
   void printTimeTaken(bool restamp = false);
 
   //////////////////
-  TwoWire *theWire = &Wire; ///< The I2C port used in scanning
-  Stream  *theSerial = &Serial; ///< The Serial port used for debugging
+  TwoWire *theWire = &Wire;    ///< The I2C port used in scanning
+  Stream *theSerial = &Serial; ///< The Serial port used for debugging
 
   float analogRef = 3.3;      ///< The default analog reference voltage
   uint16_t analogBits = 1024; ///< The default ADC resolution bits

--- a/examples/I2C_Scan/I2C_Scan.ino
+++ b/examples/I2C_Scan/I2C_Scan.ino
@@ -4,10 +4,7 @@ extern Adafruit_TestBed TB;
 #define DEFAULT_I2C_PORT &Wire
 
 // Some boards have TWO I2C ports, how nifty. We should scan both
-#if defined(ARDUINO_ADAFRUIT_KB2040_RP2040) \
-    || defined(ARDUINO_ADAFRUIT_ITSYBITSY_RP2040) \
-    || defined(ARDUINO_ADAFRUIT_QTPY_RP2040) \
-    || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040) \
+#if defined(ARDUINO_ARCH_RP2040) \
     || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) \
     || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) \
     || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3) \


### PR DESCRIPTION
Simplify preproc logic to scan both Wire and Wire1 for *any* RP2040 based board. Should help make things more universal instead of needing to keep adding new specific RP2040 boards.

Tested on:

**RPI PICO (something on both ports)**
```
Default port (Wire) I2C scan: 0x68, 
Secondary port (Wire1) I2C scan: 0x53, 
```

**QTPY RP2040 (something on both header and STEMMA QT)**
```
Default port (Wire) I2C scan: 0x53, 
Secondary port (Wire1) I2C scan: 0x68, 
```


**FEATHER RP2040 (something only on STEMMA QT)**
```
Default port (Wire) I2C scan: 
Secondary port (Wire1) I2C scan: 0x68, 
```

@ladyada 