### PR TITLE
fine tune and fix neopixel incorrect color

### DIFF
--- a/examples/Brain/usbh_test/usbh_test.ino
+++ b/examples/Brain/usbh_test/usbh_test.ino
@@ -13,6 +13,11 @@
 // CDC Host object
 Adafruit_USBH_CDC  SerialHost;
 
+enum {
+  COLOR_NO_DEV = 0x00000ff,
+  COLOR_MOUNTED = 0x00ff00,
+};
+
 //--------------------------------------------------------------------+
 // Setup and Loop on Core0
 //--------------------------------------------------------------------+
@@ -57,6 +62,8 @@ void setup1() {
   // Init Brain USB Host
   Brain.usbh_begin();
 
+  Brain.setColor(COLOR_NO_DEV);
+
   // Since we only support 1 CDC interface with Tester (also CFG_TUH_CDC = 1)
   // the index will always be 0 for SerialHost
   // SerialHost.setInterfaceIndex(0);
@@ -89,8 +96,8 @@ void tuh_mount_cb (uint8_t daddr)
   tuh_vid_pid_get(daddr, &vid, &pid);
 
   Serial.printf("Device attached, address = %d\r\n", daddr);
+  Brain.setColor(COLOR_MOUNTED);
   Brain.LCD_printf(0, "USBID %04x:%04x", vid, pid);
-
   Brain.LCD_printf(1, "MS %u HID %u CDC %u", tuh_msc_mounted(daddr), tuh_hid_instance_count(daddr), SerialHost.mounted());
 }
 
@@ -98,9 +105,9 @@ void tuh_mount_cb (uint8_t daddr)
 void tuh_umount_cb(uint8_t daddr)
 {
   Serial.printf("Device removed, address = %d\r\n", daddr);
+  Brain.setColor(COLOR_NO_DEV);
   Brain.LCD_printf(0, "No USB attached");
   Brain.LCD_printf(1, "Plug your device");
-
 }
 
 }

--- a/src/Adafruit_TestBed_Brains.cpp
+++ b/src/Adafruit_TestBed_Brains.cpp
@@ -672,7 +672,8 @@ bool Adafruit_TestBed_Brains::SD_begin(uint32_t max_clock) {
 // LCD
 //--------------------------------------------------------------------+
 
-void __no_inline_not_in_flash_func(Adafruit_TestBed_Brains::setColor)(uint32_t color) {
+void __no_inline_not_in_flash_func(Adafruit_TestBed_Brains::setColor)(
+    uint32_t color) {
   static uint32_t end_us = 0;
   static uint32_t last_color = 0x123456;
 

--- a/src/Adafruit_TestBed_Brains.cpp
+++ b/src/Adafruit_TestBed_Brains.cpp
@@ -672,15 +672,20 @@ bool Adafruit_TestBed_Brains::SD_begin(uint32_t max_clock) {
 // LCD
 //--------------------------------------------------------------------+
 
-// 1s = 1.000.000 us --> 120.000.000 nop
-// 1 us -> 120 nop
-// full frame, 1.25 us -> 150 nop
-//  - T1H 0,76 us -> 91 nop
-//  - T0H 0,36 us -> 43 nop
+void __no_inline_not_in_flash_func(Adafruit_TestBed_Brains::setColor)(uint32_t color) {
+  static uint32_t end_us = 0;
+  static uint32_t last_color = 0x123456;
 
-void Adafruit_TestBed_Brains::setColor(uint32_t color) {
-  uint8_t r = (uint8_t)(color >> 16), g = (uint8_t)(color >> 8),
-          b = (uint8_t)color;
+  if (last_color == color) {
+    // no need to update
+    return;
+  }
+  last_color = color;
+
+  uint8_t r = (uint8_t)(color >> 16); // red
+  uint8_t g = (uint8_t)(color >> 8);  // green
+  uint8_t b = (uint8_t)color;         // blue
+
   uint8_t buf[3] = {r, g, b};
 
   uint8_t *ptr, *end, p, bitMask;
@@ -691,62 +696,81 @@ void Adafruit_TestBed_Brains::setColor(uint32_t color) {
   p = *ptr++;
   bitMask = 0x80;
 
-  // 800 KHz
-  for (;;) {
+  // wait for previous frame to finish
+  enum { FRAME_TIME_US = 300 };
+
+  uint32_t now = end_us;
+  while (now - end_us < FRAME_TIME_US) {
+    now = micros();
+    if (now < end_us) {
+      // micros() overflow
+      end_us = now;
+    }
+  }
+
+  uint32_t const isr_context = save_and_disable_interrupts();
+
+  // RP2040 is 120 MHz, 120 cycle = 1us = 1000 ns
+  // Neopixel is 800 KHz, 1T = 1.25 us = 150 nop
+  while (1) {
     if (p & bitMask) {
-      // T1H 0,76 us -> 91 nop
+      // T1H 0,8 us = 96 - 1 = 95 nop
       sio_hw->gpio_set = pinMask;
-      asm("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop;");
+      __asm volatile("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;");
 
-      // 150 - 91 = 59 nop
+      // T1L 0,45 = 54 - 10 (ifelse) - 5 (overhead) = 44 nop
       sio_hw->gpio_clr = pinMask;
-      asm("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop;");
+      __asm volatile("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop;");
     } else {
-      // T0H 0,36 us -> 43 nop
+      // T0H 0,4 us = 48 - 1 = 47 nop
       sio_hw->gpio_set = pinMask;
-      asm("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop;");
+      __asm volatile("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop;");
 
-      // 150 - 43 = 107 nop
+      // T0L 0.85 us = 102 - 10 (ifelse) - 5 (overhead) = 87 nop
       sio_hw->gpio_clr = pinMask;
-      asm("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
-          "nop; nop; nop; nop; nop; nop; nop;");
+      __asm volatile("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;"
+                     "nop; nop; nop; nop;");
     }
 
-    // if a full byte is sent, next to another byte
-    if (0 == (bitMask >>= 1)) {
-      if (ptr >= end)
+    if (bitMask >>= 1) {
+      // not full byte, shift to next bit
+      __asm volatile("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;");
+    } else {
+      // probably take 10 nops
+      // if a full byte is sent, next to another byte
+      if (ptr >= end) {
         break;
+      }
       p = *ptr++;
       bitMask = 0x80;
     }
   }
+
+  restore_interrupts(isr_context);
+
+  end_us = micros();
 }
 
 void Adafruit_TestBed_Brains::lcd_write(uint8_t linenum, char linebuf[17]) {


### PR DESCRIPTION
timing for bit-baning neopixel is slightly off and can cause incorrect color randomly. This PR fine tune the timing using scope and interrupt disable/enable. Color matches much better now.