### PR TITLE
qtpy esp32s3 with psram name fix

### DIFF
--- a/examples/I2C_Scan/I2C_Scan.ino
+++ b/examples/I2C_Scan/I2C_Scan.ino
@@ -7,7 +7,7 @@ extern Adafruit_TestBed TB;
 #if defined(ARDUINO_ARCH_RP2040) \
     || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) \
     || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) \
-    || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3) \
+    || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2) \
     || defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO) \
     || defined(ARDUINO_SAM_DUE) \
     || defined(ARDUINO_ARCH_RENESAS_UNO)
@@ -26,7 +26,7 @@ void setup() {
 
 #if defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) || \
     defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) || \
-    defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3) || \
+    defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2) || \
     defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO)
   // ESP32 is kinda odd in that secondary ports must be manually
   // assigned their pins with setPins()!


### PR DESCRIPTION
Incorrect board name being used for Qt Py ESP32-S3 with 2MB PSRAM.

Code was not scanning plugged in STEMMA devices for Wire1.

was:
ARDUINO_ADAFRUIT_QTPY_ESP32S3

correct boards.txt name:
ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2

Tested on: 
Qt Py ESP32-S3
Arduino 2.3.3
ESP32 BSP 3.0.7

