### PR TITLE
Philhower's platform_def defines PICO_RP2040 and PICO_RP2350

### DIFF
--- a/src/Adafruit_TestBed_Brains.cpp
+++ b/src/Adafruit_TestBed_Brains.cpp
@@ -769,20 +769,22 @@ void __no_inline_not_in_flash_func(Adafruit_TestBed_Brains::setColor)(
      Due to overhead the number of NOP is actually smaller, also M33 run faster
      (higher IPC) therefore these are hand tuned,
   */
-#if defined(ARDUINO_RASPBERRY_PI_PICO)
+#if defined(PICO_RP2040) || defined(ARDUINO_RASPBERRY_PI_PICO)
 // value for rp2040 at 120MHz
 #define T1H_CYCLE 90
 #define T1L_CYCLE 39
 #define T0H_CYCLE 42
 #define T0L_CYCLE 84
 #define LOOP_OVERHEAD_CYCLE 10 // overhead for if/else and loop
-#elif defined(ARDUINO_RASPBERRY_PI_PICO_2)
+#elif defined(PICO_RP2350) || defined(ARDUINO_RASPBERRY_PI_PICO_2)
 // value for rp2350 at 120MHz
 #define T1H_CYCLE 190
 #define T1L_CYCLE 90
 #define T0H_CYCLE 88
 #define T0L_CYCLE 180
 #define LOOP_OVERHEAD_CYCLE 5
+#else
+#error "Unsupported RP2040-family chip for NeoPixel bit-bang timing"
 #endif
 
   while (1) {


### PR DESCRIPTION
The Arduino instructions on the learn page for the Adafruit Macro Pad say to install the Earle Philhower board support for the RP2040.  The i2c_scan example given in that tutorial won't compile with an error about NOPT1H_CYCLE is undefined.  This is because ARDUINO_RASPBERRY_PI_PICO is not defined.  However, PICO_RP2040 is.

* Scope: Changes Adafruit_TestBed_Brains.cpp.  Allows PICO_RP2040 and PICO_RP2350 to determine the CYCLE times as synonyms for ARDUINO_RASPBERRY_PI_PICO and ARDUINO_RASPBERRY_PI_PICO2.  The way the ifdef is structured, either PICO_RP2040 or ARDUINO_RASPBERRY_PI_PICO being defined will take precedence over the 2350 macros being defined.

* I tested the learn example given above.